### PR TITLE
[freebox] fix de la sauvegarde du token d'autorisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.idea/

--- a/assistant-freebox/freebox.js
+++ b/assistant-freebox/freebox.js
@@ -1,5 +1,6 @@
 var request = require('request-promise-native');
 var fs = require('fs');
+var path = require('path');
 var PromiseChain = function(arr, fct) {
   var dfd = Promise.resolve();
   var res = arr.map(function(a) {
@@ -118,7 +119,7 @@ AssistantFreebox.prototype.getAuthorization=function() {
                 // on sauvegarde la confiuration dans le fichier configuration.json
                 try {
                   var txt = "{\r\n" + JSON.stringify(_this.config).replace(/,/g, ",\r\n  ").slice(1,-1) + "\r\n}";
-                  fs.writeFileSync(__dirname + '\\configuration.json', txt, 'utf8');
+                  fs.writeFileSync(path.join(__dirname, 'configuration.json'), txt, 'utf8');
                   console.log("[assistant-freebox] Configuration terminée. Vous êtes prêt à utiliser le plugin Freebox.");
                   prom_res();
                 } catch(e) {

--- a/assistant-tag/package.json
+++ b/assistant-tag/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "assistant-tag",
+  "version": "1.0.0",
+  "description": "Plugin TAG (Transport de l'Agglomération Grenobloises) pour un Assistant",
+  "author": "ludomeurillon",
+  "main":"tag.js"
+}

--- a/assistant-tag/tag.js
+++ b/assistant-tag/tag.js
@@ -1,0 +1,78 @@
+var request = require('request-promise-native');
+var AssistantTag = function() {}
+AssistantTag.prototype.init = function(plugins) {
+    this.plugins = plugins;
+    return Promise.resolve(this);
+};
+
+AssistantTag.prototype.action = function(commande) {
+    var self= this;
+    return request({
+        'url' : 'https://data.metromobilite.fr/api/routers/default/index/clusters/SEM:GENPALJUSTI/stoptimes?route=SEM:B',
+        'method':'GET'
+    })
+        .then(function(response){
+            var results = JSON.parse(response);
+            console.log("[assistant-tag] %j", results);
+            if(!results || !results.length || !results.length || !results[1].times || !results[1].times.length){
+                if (self.plugins.notifier) {
+                    console.log("[assistant-tag] error");
+                    self.plugins.notifier.action("Je ne trouve aucun tram...");
+                }
+            } else {
+                var times = results[0].times;
+                if (results[0].pattern.dir != 1) {
+                    times = results[1].times;
+                }
+                if (self.plugins.notifier) {
+                    var resultText;
+                    var midnight = new Date();
+                    midnight.setHours(0,0,0,0);
+                    var now = new Date();
+
+                    var getMinutesFromNow = function(timeRecord){
+                        var secondsFromDayStart = timeRecord.realtimeArrival;
+                        var next = new Date(midnight.getTime() + (secondsFromDayStart * 1000));
+                        var result = (next.getTime() - now.getTime()) / 1000;
+                        var minutesFromNow = parseInt(result / 60);
+                        return minutesFromNow;
+                    };
+
+                    if(times[0]){
+                        resultText = "dans " + getMinutesFromNow(times[0]) + " minutes";
+
+                        if(times[1]){
+                            resultText += ", puis dans " + getMinutesFromNow(times[1]) + " minutes";
+                        }
+
+                        if(times[2]){
+                            resultText += ", et enfin dans " + getMinutesFromNow(times[2]) + " minutes";
+                        }
+                    } else {
+                        resultText = "Je ne trouve aucun tram...";
+
+                    }
+
+
+                    console.log("[assistant-tag] result %s", resultText);
+                    self.plugins.notifier.action(resultText);
+                }
+            }
+        })
+};
+
+/**
+ * Initialisation du plugin
+ *
+ * @param  {Object} plugins Un objet qui contient tous les plugins chargés
+ * @return {Promise} resolve(this)
+ */
+exports.init=function(plugins) {
+    var assistant = new AssistantTag();
+    return assistant.init(plugins)
+        .then(function(resource) {
+            console.log("[assistant-tag] Plugin chargé et prêt.");
+            return resource;
+        })
+}
+

--- a/plugins.json
+++ b/plugins.json
@@ -4,6 +4,7 @@
     "notifier",
     "ifttt",
     "wait",
+    "tag",
     "tam"
   ]
 }


### PR DESCRIPTION
Sur certains OS (UNIX), le plugin freebox sauvegardait le token
d'autorisation dans un mauvais fichier

Au redémarrage l'autorisation était redemandée systématiquement
sur la freebox (action manuelle).